### PR TITLE
Ensure the generated flathub:: values is compliant

### DIFF
--- a/src/cmd_publish.rs
+++ b/src/cmd_publish.rs
@@ -266,8 +266,14 @@ pub fn rewrite_appstream_xml(
 
     let mut set_value = |key: &str, value: Option<&str>| {
         if let Some(value) = value {
+            let custom = find_or_create_element(component, "custom", None);
+            find_or_create_element(custom, "value", Some(("key", key))).set_text(value);
+
+            // the <metadata> element isn't compliant with appstream
+            // leaving for backwards compatibility with older GNOME Software releases
             let metadata = find_or_create_element(component, "metadata", None);
             find_or_create_element(metadata, "value", Some(("key", key))).set_text(value);
+
             changed = true;
         }
     };


### PR DESCRIPTION
According to the spec, <metadata> is not a thing. <custom> is the correct one.

https://freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-custom

Fixes https://github.com/flathub/flathub/issues/4917