### PR TITLE
Drop unneeded AppStream backwards compatibility

### DIFF
--- a/src/cmd_publish.rs
+++ b/src/cmd_publish.rs
@@ -269,11 +269,6 @@ pub fn rewrite_appstream_xml(
             let custom = find_or_create_element(component, "custom", None);
             find_or_create_element(custom, "value", Some(("key", key))).set_text(value);
 
-            // the <metadata> element isn't compliant with appstream
-            // leaving for backwards compatibility with older GNOME Software releases
-            let metadata = find_or_create_element(component, "metadata", None);
-            find_or_create_element(metadata, "value", Some(("key", key))).set_text(value);
-
             changed = true;
         }
     };


### PR DESCRIPTION
Hi!

GNOME Software has upgraded the "metadata" tag to "custom" since ancient times, and way before the verification feature was introduced: https://gitlab.gnome.org/GNOME/gnome-software/-/blob/main/plugins/flatpak/gs-flatpak.c?ref_type=heads#L766

Therefore we can save a few bytes and simplify this by just removing the old compatibility code.

In the long run, it might make sense to add a dedicated `verified`tag to AppStream catalog metadata, but that's for the future :-)

Thanks for considering! - Please only merge this once the website is also able to handle the change :-)